### PR TITLE
Repro for https://github.com/testcontainers/testcontainers-java/issues/4594

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  dind:
+    image: docker:dind
+    command: "--tls=false"
+    privileged: true
+    environment:
+      DOCKER_TLS_CERTDIR: ""
+      DOCKER_DRIVER: overlay2
+  build:
+    image: maven
+    volumes:
+      - ".:/work"
+      - "~/.m2:/root/.m2"
+    working_dir: "/work"
+    command: "./mvnw test"
+    environment:
+      DOCKER_HOST: "tcp://dind:2375"

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>1.16.1</version>
+        <version>1.16.0</version>
     </parent>
 
     <properties>
@@ -28,6 +28,21 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>kafka</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>selenium</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-chrome-driver</artifactId>
+            <version>3.141.59</version>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-remote-driver</artifactId>
+            <version>3.141.59</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>

--- a/src/test/java/org/testcontainers/repro/ReproExampleTest.java
+++ b/src/test/java/org/testcontainers/repro/ReproExampleTest.java
@@ -3,7 +3,7 @@ package org.testcontainers.repro;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 public class ReproExampleTest {
@@ -22,10 +22,9 @@ public class ReproExampleTest {
     public void demonstration() {
         try (
             // customize the creation of a container as required
-            GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("redis:6.0.5"))
-                    .withExposedPorts(6379)
+            KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.1"))
         ) {
-            container.start();
+            kafka.start();
 
             // ...
         }

--- a/src/test/java/org/testcontainers/repro/ReproExampleTest.java
+++ b/src/test/java/org/testcontainers/repro/ReproExampleTest.java
@@ -45,7 +45,22 @@ public class ReproExampleTest {
     public void demoSelenium() {
         try (
             // customize the creation of a container as required
-            BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer().withCapabilities(new ChromeOptions());        
+            BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer().withCapabilities(new ChromeOptions())
+                    
+        ) {
+            chrome.start();
+            assertTrue(chrome.isRunning());
+            // ...
+        }
+    }
+
+    @Test
+    public void demoSeleniumSkippingRecording() {
+        try (
+            // customize the creation of a container as required
+            BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer().withCapabilities(new ChromeOptions())
+                    .withRecordingMode(org.testcontainers.containers.BrowserWebDriverContainer.VncRecordingMode.SKIP, null)
+                    
         ) {
             chrome.start();
             assertTrue(chrome.isRunning());

--- a/src/test/java/org/testcontainers/repro/ReproExampleTest.java
+++ b/src/test/java/org/testcontainers/repro/ReproExampleTest.java
@@ -1,31 +1,54 @@
 package org.testcontainers.repro;
 
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.BrowserWebDriverContainer;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.testcontainers.utility.DockerImageName;
 
 public class ReproExampleTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(ReproExampleTest.class);
 
-    /**
-     * Placeholder for a piece of code that demonstrates the bug. You can use this as a starting point, or replace
-     * entirely.
-     * <p>
-     * Ideally this would be a failing test. If it's excessively difficult to form as a test (e.g. relates to log
-     * output, teardown or other side effects) then it would be sufficient to explain the behaviour in the issue
-     * description.
-     */
     @Test
-    public void demonstration() {
+    public void demoKafka() {
         try (
             // customize the creation of a container as required
             KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.1"))
         ) {
             kafka.start();
+            assertTrue(kafka.isRunning());
 
+            // ...
+        }
+    }
+
+    @Test
+    public void demoRedis() {
+        try (
+            // customize the creation of a container as required
+            GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:6.0.5"))
+                    .withExposedPorts(6379)
+        ) {
+            redis.start();
+            assertTrue(redis.isRunning());
+
+            // ...
+        }
+    }
+
+    @Test
+    public void demoSelenium() {
+        try (
+            // customize the creation of a container as required
+            BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer().withCapabilities(new ChromeOptions());        
+        ) {
+            chrome.start();
+            assertTrue(chrome.isRunning());
             // ...
         }
     }


### PR DESCRIPTION
Change Testcontainers version from 1.16.0 to 1.16.1 (and vice versa).
`docker-compose up` to run it. 

With 1.16.0: all pass
With 1.16.1: multiple tests fail flakily. kafka always fails.